### PR TITLE
fix: Allow package to work with eslint ^2.13.0

### DIFF
--- a/babel.js
+++ b/babel.js
@@ -1,5 +1,5 @@
 module.exports = {
-  extends: './es6',
+  extends: 'habitrpg/es6',
   parser: 'babel-eslint',
   parserOptions: {
     sourceType: 'module',

--- a/browser.js
+++ b/browser.js
@@ -1,5 +1,5 @@
 module.exports = {
-  extends: '.',
+  extends: 'habitrpg',
   env: {
     browser: true,
     commonjs: true,

--- a/mocha.js
+++ b/mocha.js
@@ -1,5 +1,5 @@
 module.exports = {
-  extends: '.',
+  extends: 'habitrpg',
   env: {
     mocha: true,
   },

--- a/server.js
+++ b/server.js
@@ -1,5 +1,5 @@
 module.exports = {
-  extends: '.',
+  extends: 'habitrpg',
   env: {
     node: true,
   },


### PR DESCRIPTION
[Eslint 2.13.0 made some changes to how relative paths work when
extending](https://github.com/eslint/eslint/issues/6450), which caused
any linting that used our config to fail.

By referencing the package name instead in our sub-configs, we resolve
this erroneous behavior.

@paglias 
