### PR TITLE
prefer default only for vue files

### DIFF
--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -14,5 +14,6 @@ module.exports = {
     'no-underscore-dangle': 'off',
     'no-restricted-syntax': 'off',
     'import/no-commonjs': 'error',
+    'import/prefer-default-export': 'off',
   },
 };

--- a/lib/vue.js
+++ b/lib/vue.js
@@ -10,4 +10,12 @@ module.exports = {
     'eslint-config-habitrpg/lib/defaults',
     'plugin:vue/recommended',
   ],
+  overrides: [
+    {
+      files: ['**/*.vue'],
+      rules: {
+        'import/prefer-default-export': 'error',
+      },
+    },
+  ],
 };


### PR DESCRIPTION
This changes lint to only "prefer-default-export" on vue files. 